### PR TITLE
Add test plan and simple CI

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,31 @@
+name: Continuous Integration
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - '**.js'
+  pull_request:
+    paths:
+      - '**.php'
+      - '**.js'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - name: Check PHP syntax
+        run: |
+          find . -name '*.php' -print0 | xargs -0 -n1 php -l
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Check JS syntax
+        run: |
+          find public/js -name '*.js' -print0 | xargs -0 -n1 node -c

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,47 @@
+# Test Plan
+
+This document describes the testing strategy for the **quizProject** application. The goal is to ensure that all key features work as expected and that the codebase remains maintainable over time.
+
+## 1. Objectives
+- Validate that all functionalities operate correctly.
+- Provide a repeatable environment for running tests.
+- Ensure that results of executed tests match expected outcomes.
+- Consider technology evolution and security concerns in test cases.
+
+## 2. Test Environment
+- **PHP**: version 8.1 or above.
+- **Web Server**: built-in PHP development server (`php -S localhost:8000`).
+- **Database**: MySQL or MariaDB instance for development.
+- **Node.js**: used for JavaScript tooling (linting).
+- **GitHub Actions**: CI environment that runs on every push or pull request.
+
+The repository includes a workflow (`.github/workflows/php-lint.yml`) that installs PHP and checks syntax of all PHP files. This workflow can be extended with additional steps (e.g., PHPUnit, ESLint) as the project evolves.
+
+## 3. Test Types
+- **Unit Tests**: cover controllers and models. Use `phpunit` for PHP classes and Jest (or similar) for JavaScript modules.
+- **Integration Tests**: verify API endpoints through HTTP requests.
+- **End‑to‑End Tests**: simulate user interactions in the browser with a tool like Cypress.
+- **Security Tests**: ensure authentication, authorization, and input validation work as intended.
+
+## 4. Features to Test
+| Feature | Tests |
+| ------- | ----- |
+| **User Registration** | Valid registration, duplicate email, invalid input |
+| **User Login** | Successful login, wrong password, nonexistent user |
+| **Quiz Management** | Create quiz, update quiz, delete quiz, list user quizzes |
+| **Question Management** | Add questions, update questions, delete question |
+| **Taking Quizzes** | Retrieve quiz questions, submit answers, calculate score |
+| **Results** | Fetch user results, view detailed answers |
+
+Each test case should assert expected HTTP status codes, returned JSON structures, and correct database modifications.
+
+## 5. Execution and Expected Results
+- Tests are executed locally with `phpunit` and `npm test` once they are set up.
+- Continuous Integration runs the same test suites in GitHub Actions.
+- Results must match expected outcomes defined in the individual test cases. Failures are investigated and resolved before merging changes.
+
+## 6. Maintenance and Evolution
+- Review the test plan periodically to accommodate new features or updates in PHP and JavaScript ecosystems.
+- Keep dependencies up to date to avoid security vulnerabilities.
+- Ensure that tests cover known security concerns such as SQL injection, XSS, and privilege escalation.
+


### PR DESCRIPTION
## Summary
- document a basic test plan covering main features
- add GitHub Actions workflow for PHP and JS syntax checks

## Testing
- `find api -name '*.php' -print0 | xargs -0 -n1 php -l | tail -n 5`
- `find public/js -name '*.js' -print0 | xargs -0 -n1 node -c`

------
https://chatgpt.com/codex/tasks/task_e_6847ec074ff88322b38678b407bbbb63